### PR TITLE
Fix: Added Window Rect Implementation on Linux

### DIFF
--- a/src/window/linux/windowManagerPlatform.cpp
+++ b/src/window/linux/windowManagerPlatform.cpp
@@ -161,7 +161,14 @@ WindowRectParams WindowManager::createRenderingWindow(const char* title, int x, 
         (*s_hwndMap)[m_windowHandle] = m_index;
     }
 
-    return {};
+    XWindowAttributes windowAttributes{};
+    XGetWindowAttributes(s_display, m_windowHandle, &windowAttributes);
+    WindowRectParams windowRectParams{};
+    windowRectParams.clientWidth = windowAttributes.width;
+    windowRectParams.clientHeight = windowAttributes.height;
+    windowRectParams.windowWidth = windowAttributes.width; // TODO: Allow Caption Detection | WA: equal window and client dims
+    windowRectParams.windowHeight = windowAttributes.height; // TODO: Allow Caption Detection | WA: equal window and client dims
+    return windowRectParams;
 }
 
 void WindowManager::destroyWindow()


### PR DESCRIPTION
[branch bug-issue-9]
- Aspect Ratio returned -nan and caused the program to crash. That was because window width and height were defaulted to 0 and led to indetermination.
- Fixed creating implementation for getting window dims rect on X11 module.
