### PR TITLE
Feature & Fix: Added possibility to force GLX Context Version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,10 @@ project(HSGIL VERSION ${FULL_VERSION})
 # Project options
 option(HSGIL_BUILD_SHARED "Build HSGIL in shared mode [Static by default]." OFF)
 option(HSGIL_BUILD_EXAMPLES "Build HSGIL examples." OFF)
-option(HSGIL_DEV_OPT_1 OFF)
+option(HSGIL_FORCE_GLX_CTX_VERSION OFF)
+set(HSGIL_GLX_CTX_VERSION_MAJOR 4 CACHE STRING "Specifies Forced GLX Version Major")
+set(HSGIL_GLX_CTX_VERSION_MINOR 6 CACHE STRING "Specifies Forced GLX Version Minor")
+option(HSGIL_DEV_OPT_1 OFF) # VLD on Windows
 
 # Set C++17 as the standard
 set(CMAKE_CXX_STANDARD 17)
@@ -49,6 +52,7 @@ set(HSGIL_SOURCES
     src/window/inputHandler.cpp
     src/window/renderingWindow.cpp
     src/window/${HSGIL_PLATFORM}/windowManagerPlatform.cpp
+    src/window/${HSGIL_PLATFORM}/compatUtilsPlatform.cpp
     src/window/wmLazyPtr.cpp
     src/window/wUtils.cpp
 )
@@ -66,13 +70,24 @@ PROPERTIES
     PUBLIC_HEADER include/HSGIL/hsgil.hpp
 )
 configure_file(${HSGIL_LIB_NAME}.pc.in ${HSGIL_LIB_NAME}.pc @ONLY)
+
+# Set Dynamic Compile Definitions
+set(HSGIL_COMPILE_DEFINITIONS C__HSGIL_COMPILING)
+if(HSGIL_FORCE_GLX_CTX_VERSION)
+    set(HSGIL_COMPILE_DEFINITIONS ${HSGIL_COMPILE_DEFINITIONS}
+        C__HSGIL_FORCE_GLX_CTX_VERSION
+        C__HSGIL_GLX_CTX_VERSION_MAJOR=${HSGIL_GLX_CTX_VERSION_MAJOR}
+        C__HSGIL_GLX_CTX_VERSION_MINOR=${HSGIL_GLX_CTX_VERSION_MINOR}
+    )
+endif()
+
 if(HSGIL_BUILD_SHARED)
     target_compile_definitions(${HSGIL_LIB_NAME}
     PUBLIC
         GLAD_GLAPI_EXPORT
     PRIVATE
         __STDC_LIB_EXT1__
-        C__HSGIL_COMPILING
+        ${HSGIL_COMPILE_DEFINITIONS}
         C__HSGIL_SHARED_LIB
         GLAD_GLAPI_EXPORT_BUILD
     )
@@ -80,7 +95,7 @@ else()
     target_compile_definitions(${HSGIL_LIB_NAME}
     PRIVATE
         __STDC_LIB_EXT1__
-        C__HSGIL_COMPILING
+        ${HSGIL_COMPILE_DEFINITIONS}
     )
 endif()
 target_include_directories(${HSGIL_LIB_NAME} PRIVATE include)

--- a/include/HSGIL/window/compatUtils.hpp
+++ b/include/HSGIL/window/compatUtils.hpp
@@ -1,0 +1,39 @@
+/********************************************************************************
+ *                                                                              *
+ * HSGIL - Handy Scalable Graphics Integration Library                          *
+ * Copyright (c) 2019-2024 Adrian Bedregal                                      *
+ *                                                                              *
+ * This software is provided 'as-is', without any express or implied            *
+ * warranty. In no event will the authors be held liable for any damages        *
+ * arising from the use of this software.                                       *
+ *                                                                              *
+ * Permission is granted to anyone to use this software for any purpose,        *
+ * including commercial applications, and to alter it and redistribute it       *
+ * freely, subject to the following restrictions:                               *
+ *                                                                              *
+ * 1. The origin of this software must not be misrepresented; you must not      *
+ *    claim that you wrote the original software. If you use this software      *
+ *    in a product, an acknowledgment in the product documentation would be     *
+ *    appreciated but is not required.                                          *
+ * 2. Altered source versions must be plainly marked as such, and must not be   *
+ *    misrepresented as being the original software.                            *
+ * 3. This notice may not be removed or altered from any source distribution.   *
+ *                                                                              *
+ ********************************************************************************/
+
+#pragma once
+
+#include <HSGIL/config/config.hpp>
+#include <HSGIL/config/common.hpp>
+
+namespace gil
+{
+namespace compat
+{
+#if defined(CF__HSGIL_OS_LINUX)
+HSGIL_API void forceGlxContextToVersion(const int major, const int minor);
+#endif
+
+} // namespace compat
+
+} // namespace gil

--- a/src/graphics/shader.cpp
+++ b/src/graphics/shader.cpp
@@ -23,6 +23,9 @@
 
 #include <HSGIL/graphics/shader.hpp>
 
+#include <HSGIL/exception/graphics/graphicsException.hpp>
+
+#include <cctype>
 #include <string>
 #include <fstream>
 #include <sstream>
@@ -34,6 +37,40 @@ Shader::Shader(const std::string& t_name)
 {
     std::string vsSrc {loadShaderFromFile(GL_VERTEX_SHADER, "shaders/" + t_name)};
     std::string fsSrc {loadShaderFromFile(GL_FRAGMENT_SHADER, "shaders/" + t_name)};
+
+#if defined(C__HSGIL_FORCE_GLX_CTX_VERSION)
+    constexpr int glxCtxMajorVersion{ C__HSGIL_GLX_CTX_VERSION_MAJOR };
+    constexpr int glxCtxMinorVersion{ C__HSGIL_GLX_CTX_VERSION_MINOR };
+    const auto replaceGlxContextVersion = [](std::string& shaderSrc) -> void {
+        const size_t versionDeclIdx = shaderSrc.find("#version");
+        size_t versionDefStartIdx = versionDeclIdx + 9;
+        while ((versionDefStartIdx < shaderSrc.size()) && !std::isdigit(shaderSrc[versionDefStartIdx]))
+        {
+            ++versionDefStartIdx;
+        }
+        size_t versionDefEndIdx = versionDefStartIdx + 1;
+        while ((versionDefEndIdx < shaderSrc.size()) && std::isdigit(shaderSrc[versionDefEndIdx]))
+        {
+            ++versionDefEndIdx;
+        }
+        if ((versionDefStartIdx >= shaderSrc.size()) || (versionDefEndIdx >= shaderSrc.size()))
+        {
+            throw GraphicsException();
+        }
+        std::string glxCtxVersionStr = std::to_string(glxCtxMajorVersion) + std::to_string(glxCtxMinorVersion) + std::string("0");
+        shaderSrc.replace(versionDefStartIdx, versionDefEndIdx - versionDefStartIdx, glxCtxVersionStr);
+    };
+
+    try
+    {
+        replaceGlxContextVersion(vsSrc);
+        replaceGlxContextVersion(fsSrc);
+    }
+    catch (const GenericException& e)
+    {
+        std::cerr << "An Exception has occurred: " << e.what() << std::endl;
+    }
+#endif
 
     uint32 vertexShader {createShader(GL_VERTEX_SHADER, vsSrc)};
     uint32 fragmentShader {createShader(GL_FRAGMENT_SHADER, fsSrc)};

--- a/src/window/linux/compatUtilsPlatform.cpp
+++ b/src/window/linux/compatUtilsPlatform.cpp
@@ -1,0 +1,39 @@
+/********************************************************************************
+ *                                                                              *
+ * HSGIL - Handy Scalable Graphics Integration Library                          *
+ * Copyright (c) 2019-2024 Adrian Bedregal                                      *
+ *                                                                              *
+ * This software is provided 'as-is', without any express or implied            *
+ * warranty. In no event will the authors be held liable for any damages        *
+ * arising from the use of this software.                                       *
+ *                                                                              *
+ * Permission is granted to anyone to use this software for any purpose,        *
+ * including commercial applications, and to alter it and redistribute it       *
+ * freely, subject to the following restrictions:                               *
+ *                                                                              *
+ * 1. The origin of this software must not be misrepresented; you must not      *
+ *    claim that you wrote the original software. If you use this software      *
+ *    in a product, an acknowledgment in the product documentation would be     *
+ *    appreciated but is not required.                                          *
+ * 2. Altered source versions must be plainly marked as such, and must not be   *
+ *    misrepresented as being the original software.                            *
+ * 3. This notice may not be removed or altered from any source distribution.   *
+ *                                                                              *
+ ********************************************************************************/
+
+#include <HSGIL/window/compatUtils.hpp>
+
+#include "windowManagerPlatform.hpp"
+
+namespace gil
+{
+namespace compat
+{
+void forceGlxContextToVersion(const int major, const int minor)
+{
+    WindowManager::internalSetGlxContextVersion(major, minor);
+}
+
+} // namespace compat
+
+} // namespace gil

--- a/src/window/linux/windowManagerPlatform.cpp
+++ b/src/window/linux/windowManagerPlatform.cpp
@@ -69,6 +69,8 @@ GLXFBConfig* WindowManager::s_fbConfigs {nullptr};
 
 bool WindowManager::s_vSyncCompat {true};
 bool WindowManager::s_attribCtxCompat {true};
+int WindowManager::s_glxCtxVersionMajorCompat {4};
+int WindowManager::s_glxCtxVersionMinorCompat {6};
 
 PFNGLXCREATECONTEXTATTRIBSARBPROC WindowManager::glXCreateContextAttribsARB {nullptr};
 
@@ -245,10 +247,14 @@ WindowManager::~WindowManager()
 
 void WindowManager::createContext()
 {
+#if defined(C__HSGIL_FORCE_GLX_CTX_VERSION)
+    internalSetGlxContextVersion(C__HSGIL_GLX_CTX_VERSION_MAJOR, C__HSGIL_GLX_CTX_VERSION_MINOR);
+#endif
+
     int contextAttribs[] =
     {
-        GLX_CONTEXT_MAJOR_VERSION_ARB, 4,
-		GLX_CONTEXT_MINOR_VERSION_ARB, 6,
+        GLX_CONTEXT_MAJOR_VERSION_ARB, s_glxCtxVersionMajorCompat,
+		GLX_CONTEXT_MINOR_VERSION_ARB, s_glxCtxVersionMinorCompat,
 		GLX_CONTEXT_FLAGS_ARB, GLX_CONTEXT_FORWARD_COMPATIBLE_BIT_ARB,
 		None
 	};
@@ -276,6 +282,12 @@ void WindowManager::createContext()
     gladLoadGL();
 
     std::cout << "Context Created" << std::endl;
+}
+
+void WindowManager::internalSetGlxContextVersion(const int major, const int minor)
+{
+    s_glxCtxVersionMajorCompat = major;
+    s_glxCtxVersionMinorCompat = minor;
 }
 
 void WindowManager::loadInputMap()

--- a/src/window/linux/windowManagerPlatform.hpp
+++ b/src/window/linux/windowManagerPlatform.hpp
@@ -36,6 +36,7 @@
 #include <HSGIL/window/inputEvents.hpp>
 #include <HSGIL/window/inputBindings.hpp>
 #include <HSGIL/window/customization.hpp>
+#include <HSGIL/window/compatUtils.hpp>
 
 #include "../safePtr.hpp"
 #include "../wmLazyPtr.hpp"
@@ -68,6 +69,7 @@ typedef int  (*PFNGLXSWAPINTERVALPROC2)(int);
 class HSGIL_API WindowManager final
 {
     friend HSGIL_API WMLazyPtr;
+    friend HSGIL_API void compat::forceGlxContextToVersion(const int major, const int minor);
 public:
     static WindowManager* createInstance();
     static WindowManager* getInstance(const uint32 index);
@@ -136,12 +138,16 @@ private:
 
     static bool s_vSyncCompat;
     static bool s_attribCtxCompat;
+    static int s_glxCtxVersionMajorCompat;
+    static int s_glxCtxVersionMinorCompat;
 
     static PFNGLXCREATECONTEXTATTRIBSARBPROC glXCreateContextAttribsARB;
 
     static bool glXSwapIntervalEXTMode;
     static PFNGLXSWAPINTERVALPROC1 glXSwapInterval1;
     static PFNGLXSWAPINTERVALPROC2 glXSwapInterval2;
+
+    static void internalSetGlxContextVersion(const int major, const int minor);
 
     static void loadInputMap();
     static int rawToStandard(int rawCode);


### PR DESCRIPTION
[branch feat-issue-8]
- Created a compatibility module for enabling current and future workarounds for compatibility.
- Created a shader wrapper to allow replacing (forced) version declaration.
- Modified CMake file to enable that option.